### PR TITLE
White list actions

### DIFF
--- a/argumentlist.go
+++ b/argumentlist.go
@@ -1,0 +1,14 @@
+package main
+
+import "strings"
+
+type argumentList []string
+
+func (l argumentList) String() string {
+	return strings.Join(l, ",")
+}
+
+func (a *argumentList) Set(value string) error {
+	*a = append(*a, strings.Split(value, ",")...)
+	return nil
+}

--- a/handlers/allowedactions.go
+++ b/handlers/allowedactions.go
@@ -23,7 +23,7 @@ func NewAllowedActions(l log.Logger, allowedActions []string) func(h http.Handle
 			action := r.URL.Path[1:]
 			if _, exists := actions[action]; !exists {
 				l.Log("error", "action is not white-listed", "action", action, "allowed", strings.Join(allowedActions, ","))
-				http.Error(w, "Unregisterd action", http.StatusNotAcceptable)
+				http.Error(w, "Unregisterd action", http.StatusBadRequest)
 				return
 			}
 

--- a/handlers/allowedactions.go
+++ b/handlers/allowedactions.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"net/http"
+
+	"strings"
+
+	"github.com/go-kit/kit/log"
+)
+
+func NewAllowedActions(l log.Logger, allowedActions []string) func(h http.Handler) http.Handler {
+	var actions = make(map[string]bool, len(allowedActions))
+	for _, p := range allowedActions {
+		if p == "" {
+			continue
+		}
+
+		actions[p] = true
+	}
+
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			action := r.URL.Path[1:]
+			if _, exists := actions[action]; !exists {
+				l.Log("error", "action is not white-listed", "action", action, "allowed", strings.Join(allowedActions, ","))
+				http.Error(w, "Unregisterd action", http.StatusNotAcceptable)
+				return
+			}
+
+			h.ServeHTTP(w, r)
+		})
+	}
+}

--- a/handlers/allowedparams.go
+++ b/handlers/allowedparams.go
@@ -25,7 +25,7 @@ func NewAllowedParams(l log.Logger, allowedParams []string) func(h http.Handler)
 			for p := range requestParams {
 				if _, exists := params[p]; !exists {
 					l.Log("error", "parameter is not white-listed", "parameter", p, "allowed", strings.Join(allowedParams, ","))
-					http.Error(w, "Unregisterd parameter", http.StatusNotAcceptable)
+					http.Error(w, "Unregisterd parameter", http.StatusBadRequest)
 					return
 				}
 			}

--- a/handlers/allowedparams.go
+++ b/handlers/allowedparams.go
@@ -1,0 +1,36 @@
+package handlers
+
+import (
+	"net/http"
+
+	"strings"
+
+	"github.com/go-kit/kit/log"
+)
+
+func NewAllowedParams(l log.Logger, allowedParams []string) func(h http.Handler) http.Handler {
+	var params = make(map[string]bool, len(allowedParams))
+	for _, p := range allowedParams {
+		if p == "" {
+			continue
+		}
+
+		params[p] = true
+	}
+
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestParams := r.URL.Query()
+
+			for p := range requestParams {
+				if _, exists := params[p]; !exists {
+					l.Log("error", "parameter is not white-listed", "parameter", p, "allowed", strings.Join(allowedParams, ","))
+					http.Error(w, "Unregisterd parameter", http.StatusNotAcceptable)
+					return
+				}
+			}
+
+			h.ServeHTTP(w, r)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"time"
 
-	"strings"
-
 	"flag"
 
 	"fmt"
@@ -20,7 +18,7 @@ import (
 
 var (
 	allowedHosts           argumentList
-	allowedImaginaryParams string
+	allowedImaginaryParams argumentList
 	imaginaryURL           string
 	listenPort             int64
 	bucketRate             float64
@@ -34,24 +32,13 @@ var (
 	)
 )
 
-type argumentList []string
-
-func (l argumentList) String() string {
-	return strings.Join(l, ",")
-}
-
-func (l *argumentList) Set(value string) error {
-	*l = append(*l, value)
-	return nil
-}
-
 func init() {
-	flag.Var(&allowedHosts, "allow-host", "Repeatable flag for hosts to allow for the URL parameter (e.g. \"d2dktr6aauwgqs.cloudfront.net\")")
+	flag.Var(&allowedHosts, "allow-host", "Repeatable flag (or a comma-separated list) for hosts to allow for the URL parameter (e.g. \"d2dktr6aauwgqs.cloudfront.net\")")
 	flag.StringVar(&imaginaryURL, "imaginary-url", "http://localhost:9000", "URL to imaginary (default: http://localhost:9000)")
 	flag.Int64Var(&listenPort, "listen-port", 8080, "Port to listen on")
 	flag.Float64Var(&bucketRate, "bucket-rate", 20, "Rate limiter bucket fill rate (req/s)")
 	flag.Int64Var(&bucketSize, "bucket-size", 500, "Rate limiter bucket size (burst capacity)")
-	flag.StringVar(&allowedImaginaryParams, "allowed-params", "", "A comma seperated list of parameters allows to be sent upstream. If empty, everything is allowed.")
+	flag.Var(&allowedImaginaryParams, "allowed-params", "A comma seperated list of parameters allows to be sent upstream. If empty, everything is allowed.")
 
 }
 
@@ -62,6 +49,7 @@ func main() {
 		"msg", "Starting.",
 		"version", Version,
 		"allowed_hosts", allowedHosts.String(),
+		"allowed_params", allowedImaginaryParams.String(),
 		"imaginary_backend", imaginaryURL,
 	)
 
@@ -102,12 +90,12 @@ func decorateHandler(h http.Handler, b *ratelimit.Bucket) http.Handler {
 		handlers.NewValidateURLParameter(logger, allowedHosts),
 	}
 
-	if allowedImaginaryParams != "" {
+	if len(allowedImaginaryParams) > 0 {
 		decorators = append(
 			decorators,
 			handlers.NewAllowedParams(
 				logger,
-				strings.Split(allowedImaginaryParams, ","),
+				allowedImaginaryParams,
 			))
 	}
 

--- a/main.go
+++ b/main.go
@@ -33,12 +33,13 @@ var (
 )
 
 func init() {
-	flag.Var(&allowedHosts, "allow-host", "Repeatable flag (or a comma-separated list) for hosts to allow for the URL parameter (e.g. \"d2dktr6aauwgqs.cloudfront.net\")")
+	flag.Var(&allowedHosts, "allow-hosts", "Repeatable flag (or a comma-separated list) for hosts to allow for the URL parameter (e.g. \"d2dktr6aauwgqs.cloudfront.net\")")
+	flag.Var(&allowedImaginaryParams, "allowed-params", "A comma seperated list of parameters allows to be sent upstream. If empty, everything is allowed.")
+
 	flag.StringVar(&imaginaryURL, "imaginary-url", "http://localhost:9000", "URL to imaginary (default: http://localhost:9000)")
 	flag.Int64Var(&listenPort, "listen-port", 8080, "Port to listen on")
 	flag.Float64Var(&bucketRate, "bucket-rate", 20, "Rate limiter bucket fill rate (req/s)")
 	flag.Int64Var(&bucketSize, "bucket-size", 500, "Rate limiter bucket size (burst capacity)")
-	flag.Var(&allowedImaginaryParams, "allowed-params", "A comma seperated list of parameters allows to be sent upstream. If empty, everything is allowed.")
 
 }
 

--- a/main.go
+++ b/main.go
@@ -19,12 +19,13 @@ import (
 )
 
 var (
-	allowedHosts           argumentList
-	allowedImaginaryParams string
-	imaginaryURL           string
-	listenPort             int64
-	bucketRate             float64
-	bucketSize             int64
+	allowedHosts            argumentList
+	allowedImaginaryParams  string
+	allowedImaginaryActions string
+	imaginaryURL            string
+	listenPort              int64
+	bucketRate              float64
+	bucketSize              int64
 
 	Version = "dev"
 	logger  = log.With(
@@ -52,6 +53,7 @@ func init() {
 	flag.Float64Var(&bucketRate, "bucket-rate", 20, "Rate limiter bucket fill rate (req/s)")
 	flag.Int64Var(&bucketSize, "bucket-size", 500, "Rate limiter bucket size (burst capacity)")
 	flag.StringVar(&allowedImaginaryParams, "allowed-params", "", "A comma seperated list of parameters allows to be sent upstream. If empty, everything is allowed.")
+	flag.StringVar(&allowedImaginaryActions, "allowed-actions", "", "A comma seperated list of actions allows to be sent upstream. If empty, everything is allowed.")
 
 }
 
@@ -108,6 +110,15 @@ func decorateHandler(h http.Handler, b *ratelimit.Bucket) http.Handler {
 			handlers.NewAllowedParams(
 				logger,
 				strings.Split(allowedImaginaryParams, ","),
+			))
+	}
+
+	if allowedImaginaryActions != "" {
+		decorators = append(
+			decorators,
+			handlers.NewAllowedActions(
+				logger,
+				strings.Split(allowedImaginaryActions, ","),
 			))
 	}
 


### PR DESCRIPTION
Only allow a predefined set of actions, e.g.:

```
./proxima -allowed-actions=crop,resize
```

With:
```
/enlarge?width=100&height=100&file=/path/to/image.jpg
```

would result in:
```
error="action is not white-listed" action=enlarge allowed=crop,resize
```

This prevents abuse such as: `/enlarge?width=10000&height=10000..`