### PR TITLE
Path stripping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# Introduction
+Proxima is a small reverse-proxy intended to guard the popular [Imaginary](https://github.com/h2non/imaginary) service. It's intended as a public facing frontend for Imaginary.  

--- a/handlers/pathstrip.go
+++ b/handlers/pathstrip.go
@@ -1,0 +1,22 @@
+package handlers
+
+import (
+	"net/http"
+
+	"strings"
+
+	"github.com/go-kit/kit/log"
+)
+
+// NewPathStrip strips the path from the request URL, paths always start with a /.
+func NewPathStrip(_ log.Logger, path string) func(h http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasPrefix(r.URL.Path, path) {
+				r.URL.Path = strings.TrimPrefix(r.URL.Path, path)
+			}
+
+			h.ServeHTTP(w, r)
+		})
+	}
+}

--- a/handlers/ratelimiter.go
+++ b/handlers/ratelimiter.go
@@ -8,7 +8,7 @@ import (
 	"github.com/juju/ratelimit"
 )
 
-func NewRateLimitHandler(b *ratelimit.Bucket, l log.Logger) func(h http.Handler) http.Handler {
+func NewRateLimitHandler(l log.Logger, b *ratelimit.Bucket) func(h http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			d := b.Take(1)

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 	}
 
 	rlBucket := ratelimit.NewBucketWithRate(bucketRate, bucketSize)
-	proxy := newProxy(rURL, logger)
+	proxy := newProxy(logger, rURL)
 
 	s := &http.Server{
 		Addr:              fmt.Sprintf(":%d", listenPort),
@@ -82,7 +82,7 @@ func main() {
 	s.ListenAndServe()
 }
 
-func newProxy(backend *url.URL, l log.Logger) *httputil.ReverseProxy {
+func newProxy(l log.Logger, backend *url.URL) *httputil.ReverseProxy {
 	proxy := httputil.NewSingleHostReverseProxy(backend)
 	proxy.ErrorLog = stdlog.New(log.NewStdlibAdapter(l), "", stdlog.LstdFlags)
 	proxy.Transport = &http.Transport{


### PR DESCRIPTION
This feature allows you to strip a part of the path being sent to Imaginary.

An example:

```
./proxima -root-path-strip=/static
```

With:
```
/static/enlarge?width=100&height=100&file=/path/to/image.jpg
```

Sents the path `/enlarge` to Imaginary, instead of `/static/enlarge`

This is useful when dealing with (e.g.) GKE's L7 firewalls